### PR TITLE
Add minimal CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]


### PR DESCRIPTION
We need a way to keep track of new release information. With other projects, we have traditionally hand-written a CHANGELOG. Personally, I like this approach because we typically draft our messages to emphasize the impact of changes on our users, and a CHANGELOG file is a standard, discoverable way of seeing what changed.

However, I'm open to discussing whether we would prefer to use [GitHub Releases](https://docs.github.com/en/enterprise/2.13/user/articles/creating-releases) instead or try to automate the CHANGELOG in some way.