### PR TITLE
Upgrade rake development dependency

### DIFF
--- a/newrelic-telemetry_sdk.gemspec
+++ b/newrelic-telemetry_sdk.gemspec
@@ -28,6 +28,6 @@ EOS
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
For security reasons, our version of rake should be constrained to versions at or above 12.3.3.