### PR TITLE
Convenience method for creating spans

### DIFF
--- a/lib/new_relic/telemetry_sdk/span.rb
+++ b/lib/new_relic/telemetry_sdk/span.rb
@@ -17,6 +17,32 @@ module NewRelic
                     :service_name,
                     :custom_attributes
 
+      def self.wrap id: Util.generate_guid(8),
+                    trace_id: Util.generate_guid(16),
+                    start_time_ms: Util.time_to_ms,
+                    duration_ms: nil,
+                    name: nil,
+                    parent_id: nil,
+                    service_name: nil,
+                    custom_attributes: nil
+        span = Span.new id: id,
+                        trace_id: trace_id,
+                        start_time_ms: start_time_ms,
+                        duration_ms: duration_ms,
+                        name: name,
+                        parent_id: parent_id,
+                        service_name: service_name,
+                        custom_attributes: custom_attributes
+        begin
+          yield
+        rescue => exception
+          # Log issue with span creation
+        ensure
+          span.finish if span
+        end
+        span
+      end
+
       def initialize id: Util.generate_guid(8),
                      trace_id: Util.generate_guid(16),
                      start_time_ms: Util.time_to_ms,

--- a/test/new_relic/telemetry_sdk/span_test.rb
+++ b/test/new_relic/telemetry_sdk/span_test.rb
@@ -129,6 +129,14 @@ module NewRelic
 
         assert_equal expected_data, span.to_json
       end
+
+      def test_wrapping_block_in_span
+        span = Span.wrap do
+          'foo' * 5
+        end
+
+        refute_nil span
+      end
     end
   end
 end


### PR DESCRIPTION
The goal of this PR is to make it easier for users to create spans wrapped around blocks of work, without having to manually call `start` or `finish` on the span.

The interface for the current implementation would be:

```
span = Span.wrap do
  # do something
end
# Send span to NR via client or harvester
```

Looking forward to feedback on whether this is a sufficiently convenient setup or whether there's something more intuitive.