### PR TITLE
expanded the server response handling with all conditional cases

### DIFF
--- a/lib/new_relic/telemetry_sdk/clients/client.rb
+++ b/lib/new_relic/telemetry_sdk/clients/client.rb
@@ -84,7 +84,9 @@ module NewRelic
         end
       end
 
-      def calculate_backoff_strategy connection_attempts = @connection_attempts, backoff_factor = @backoff_factor, backoff_max = @backoff_max
+      def calculate_backoff_strategy connection_attempts = @connection_attempts, 
+                                     backoff_factor = @backoff_factor, 
+                                     backoff_max = @backoff_max
         [backoff_max, (backoff_factor * (2**(connection_attempts-1)).to_i)].min
       end
 

--- a/lib/new_relic/telemetry_sdk/clients/client.rb
+++ b/lib/new_relic/telemetry_sdk/clients/client.rb
@@ -57,6 +57,11 @@ module NewRelic
       end
 
       def log_and_split_payload response, data, common_attributes
+        # TODO: log response
+        # splits the data in half and calls report_batch for each half
+        data1, data2 = data.each_slice((data.size/2.0).round).to_a
+        report_batch [data1, common_attributes]
+        report_batch [data2, common_attributes]
       end
       
       def log_and_retry_with_backoff response, post_body

--- a/lib/new_relic/telemetry_sdk/clients/client.rb
+++ b/lib/new_relic/telemetry_sdk/clients/client.rb
@@ -69,8 +69,8 @@ module NewRelic
         end
       end
 
-      def calculate_backoff_strategy
-        [@backoff_max, (@backoff_factor * (2**(@connection_attempts-1)).to_i)].min
+      def calculate_backoff_strategy connection_attempts = @connection_attempts, backoff_factor = @backoff_factor, backoff_max = @backoff_max
+        [backoff_max, (backoff_factor * (2**(connection_attempts-1)).to_i)].min
       end
 
       def backoff_strategy

--- a/lib/new_relic/telemetry_sdk/clients/client.rb
+++ b/lib/new_relic/telemetry_sdk/clients/client.rb
@@ -61,10 +61,15 @@ module NewRelic
       def log_and_split_payload response, data, common_attributes
         logger.error "Payload too large. Splitting payload in half and attempting to resend."
         logger.error response.message
-        # splits the data in half and calls report_batch for each half
-        midpoint = data.size/2.0
-        report_batch [data.first(midpoint.ceil), common_attributes]
-        report_batch [data.last(midpoint.floor), common_attributes]
+        if data.size > 1
+          # splits the data in half and calls report_batch for each half
+          midpoint = data.size/2.0
+          report_batch [data.first(midpoint.ceil), common_attributes]
+          report_batch [data.last(midpoint.floor), common_attributes]
+        else 
+          # payload cannot be split, drop data
+          logger.error "Unable to split payload. Dropping data: #{data.size} points of data"
+        end
       end
       
       def log_and_retry_with_backoff response, data

--- a/lib/new_relic/telemetry_sdk/clients/client.rb
+++ b/lib/new_relic/telemetry_sdk/clients/client.rb
@@ -62,9 +62,9 @@ module NewRelic
         logger.error "Payload too large. Splitting payload in half and attempting to resend."
         logger.error response.message
         # splits the data in half and calls report_batch for each half
-        data1, data2 = data.each_slice((data.size/2.0).round).to_a
-        report_batch [data1, common_attributes]
-        report_batch [data2, common_attributes]
+        midpoint = data.size/2.0
+        report_batch [data.first(midpoint.ceil), common_attributes]
+        report_batch [data.last(midpoint.floor), common_attributes]
       end
       
       def log_and_retry_with_backoff response, data

--- a/lib/new_relic/telemetry_sdk/clients/client.rb
+++ b/lib/new_relic/telemetry_sdk/clients/client.rb
@@ -5,6 +5,7 @@
 
 require 'new_relic/telemetry_sdk/buffer'
 require 'new_relic/telemetry_sdk/logger'
+require 'new_relic/telemetry_sdk/exception'
 
 module NewRelic
   module TelemetrySdk
@@ -22,6 +23,10 @@ module NewRelic
         @gzip_request = use_gzip
         @payload_type = payload_type
         add_content_encoding_header @headers if @gzip_request
+        @connection_attempts = 0
+        @max_retries= 8 # based on config
+        @backoff_factor = 5 # based on config
+        @backoff_max = 80 # based on config
       end
 
       def send_request body
@@ -36,9 +41,15 @@ module NewRelic
       end
 
       def log_and_retry response, post_body
+        # TODO: log each time
+        raise NewRelic::TelemetrySdk::ServerConnectionException
       end
 
       def log_and_retry_later response, post_body
+        # TODO: log each time
+        wait_time = response['Retry-After'].to_i # do we 
+        sleep wait_time
+        raise NewRelic::TelemetrySdk::ServerConnectionException
       end
 
       def log_once_and_drop_data response
@@ -49,6 +60,23 @@ module NewRelic
       end
       
       def log_and_retry_with_backoff response, post_body
+        if @connection_attempts < @max_retries
+          # TODO: log each time
+          sleep backoff_strategy 
+          raise NewRelic::TelemetrySdk::ServerConnectionException
+        else 
+          # TODO: log 
+        end
+      end
+
+      def calculate_backoff_strategy
+        [@backoff_max, (@backoff_factor * (2**(@connection_attempts-1)).to_i)].min
+      end
+
+      def backoff_strategy
+        wait = calculate_backoff_strategy
+        @connection_attempts += 1
+        wait 
       end
 
       def report_batch batch_data
@@ -62,21 +90,23 @@ module NewRelic
         @headers[:'x-request-id'] = SecureRandom.uuid
 
         post_body = format_payload data, common_attributes
+      begin
         response = send_request post_body
 
         case response
         when Net::HTTPSuccess # 200 - 299
-   
+          @connection_attempts = 0 # reset count after sucessful connection
+        
         when Net::HTTPBadRequest, # 400
-             Net::HTTPUnauthorized, # 401
-             Net::HTTPForbidden, # 403
-             Net::HTTPNotFound, # 404
-             Net::HTTPMethodNotAllowed, # 405
-             Net::HTTPConflict, # 409
-             Net::HTTPGone, # 410
-             Net::HTTPLengthRequired  # 411
+            Net::HTTPUnauthorized, # 401
+            Net::HTTPForbidden, # 403
+            Net::HTTPNotFound, # 404
+            Net::HTTPMethodNotAllowed, # 405
+            Net::HTTPConflict, # 409
+            Net::HTTPGone, # 410
+            Net::HTTPLengthRequired  # 411
           log_once_and_drop_data response
-   
+  
         when Net::HTTPRequestTimeOut # 408
           log_and_retry response, post_body
 
@@ -89,6 +119,10 @@ module NewRelic
         else
           log_and_retry_with_backoff response, post_body
         end
+
+      rescue NewRelic::TelemetrySdk::ServerConnectionException
+        retry
+      end
       end
 
       def format_payload data, common_attributes

--- a/lib/new_relic/telemetry_sdk/clients/client.rb
+++ b/lib/new_relic/telemetry_sdk/clients/client.rb
@@ -4,10 +4,13 @@
 # See https://github.com/newrelic/newrelic-telemetry-sdk-ruby/blob/main/LICENSE for complete details.
 
 require 'new_relic/telemetry_sdk/buffer'
+require 'new_relic/telemetry_sdk/logger'
 
 module NewRelic
   module TelemetrySdk
     class Client
+      include NewRelic::TelemetrySdk::Logger
+      
       def initialize host:,
                      path:,
                      headers: {},
@@ -39,6 +42,7 @@ module NewRelic
       end
 
       def log_once_and_drop_data response
+        log_error_once response.class, response.message
       end
 
       def log_and_split_payload response, data, common_attributes

--- a/lib/new_relic/telemetry_sdk/exception.rb
+++ b/lib/new_relic/telemetry_sdk/exception.rb
@@ -1,0 +1,10 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+
+module NewRelic
+  module TelemetrySdk
+    class ServerConnectionException < StandardError; end
+  end
+end

--- a/lib/new_relic/telemetry_sdk/exception.rb
+++ b/lib/new_relic/telemetry_sdk/exception.rb
@@ -5,6 +5,6 @@
 
 module NewRelic
   module TelemetrySdk
-    class ServerConnectionException < StandardError; end
+    class RetriableServerResponseException < StandardError; end
   end
 end

--- a/lib/new_relic/telemetry_sdk/logger.rb
+++ b/lib/new_relic/telemetry_sdk/logger.rb
@@ -1,0 +1,44 @@
+module NewRelic
+  module TelemetrySdk
+    module Logger
+      LOG_LEVELS = %w{debug info warn error fatal}
+
+      LOG_LEVELS.each do |level|
+        define_method "log_#{level}_once" do |key, *msgs|
+          log_once level, key, *msgs
+        end
+      end
+
+      def logger
+        @logger ||= ::Logger.new(STDOUT)
+      end
+
+      def logger= logger
+        @logger = logger
+      end
+
+      def logger_mutex
+        @logger_mutex ||= Mutex.new
+      end
+
+      def already_logged
+        @already_logged ||= {}
+      end
+
+      def log_once(level, key, *msgs)
+        logger_mutex.synchronize do
+          return if already_logged.include?(key)
+          already_logged[key] = true
+        end
+
+        logger.send(level, *msgs)
+      end
+
+      def clear_already_logged
+        already_logged_lock.synchronize do
+          @already_logged = {}
+        end
+      end
+    end
+  end
+end

--- a/test/new_relic/telemetry_sdk/clients/client_test.rb
+++ b/test/new_relic/telemetry_sdk/clients/client_test.rb
@@ -25,7 +25,7 @@ module NewRelic
         @item = ItemStub.new
       end
 
-      # Stups sleep in the client and expects it to never be called
+      # Stubs sleep in the client and expects it to never be called
       def never_sleep 
         @sleep = @client.stubs(:sleep)
         @sleep.never
@@ -87,7 +87,7 @@ module NewRelic
       
       def test_status_request_timeout
         never_sleep
-        # Returns 208 once and then 200 once, expects exactly 2 calls
+        # Returns 408 once and then 200 once, expects exactly 2 calls
         stub_server(408).then.returns(stub_response 200).times(2)
         @client.report @item
       end

--- a/test/new_relic/telemetry_sdk/clients/client_test.rb
+++ b/test/new_relic/telemetry_sdk/clients/client_test.rb
@@ -149,14 +149,14 @@ module NewRelic
         @client.instance_variable_set(:@max_retries, 5)
         @client.instance_variable_set(:@connection_attempts, 4)
         assert_raises NewRelic::TelemetrySdk::ServerConnectionException do 
-          @client.log_and_retry_with_backoff(stub_response(413), mock)
+          @client.log_and_retry_with_backoff(stub_response(413), [mock])
         end
       end
 
       def test_reaching_max_attempts_stops_retrying
         @client.instance_variable_set(:@max_retries, 5)
         @client.instance_variable_set(:@connection_attempts, 5)
-        @client.log_and_retry_with_backoff(stub_response(413), mock)
+        @client.log_and_retry_with_backoff(stub_response(413), [mock])
       end
 
       def test_splitting_payload

--- a/test/new_relic/telemetry_sdk/clients/client_test.rb
+++ b/test/new_relic/telemetry_sdk/clients/client_test.rb
@@ -52,6 +52,36 @@ module NewRelic
         @client.report @item
       end
 
+      def test_status_not_found
+        @sleep.never
+        stub_server(404).once
+        @client.report @item
+      end
+      
+      def test_status_request_timeout
+        @sleep.never
+        stub_server(408).once
+        @client.report @item
+      end
+
+      def test_status_request_entity_too_large
+        @sleep.never
+        stub_server(413).once
+        @client.report @item
+      end
+
+      def test_status_request_too_many_requests
+        @sleep.never
+        stub_server(429).once
+        @client.report @item
+      end
+
+      def test_status_server_error
+        @sleep.never
+        stub_server(500).once
+        @client.report @item
+      end
+
       def stub_server status, message = 'default message'
         response = stub_response status, message
         @connection.stubs(:post).returns response

--- a/test/new_relic/telemetry_sdk/clients/client_test.rb
+++ b/test/new_relic/telemetry_sdk/clients/client_test.rb
@@ -148,7 +148,7 @@ module NewRelic
         @client.expects(:backoff_strategy).then.returns(0).once
         @client.instance_variable_set(:@max_retries, 5)
         @client.instance_variable_set(:@connection_attempts, 4)
-        assert_raises NewRelic::TelemetrySdk::ServerConnectionException do 
+        assert_raises NewRelic::TelemetrySdk::RetriableServerResponseException do 
           @client.log_and_retry_with_backoff(stub_response(413), [mock])
         end
       end

--- a/test/new_relic/telemetry_sdk/clients/client_test.rb
+++ b/test/new_relic/telemetry_sdk/clients/client_test.rb
@@ -148,6 +148,7 @@ module NewRelic
         @client.expects(:backoff_strategy).then.returns(0).once
         @client.instance_variable_set(:@max_retries, 5)
         @client.instance_variable_set(:@connection_attempts, 4)
+        # Retry raises an exception, so we want the exception raised here
         assert_raises NewRelic::TelemetrySdk::RetriableServerResponseException do 
           @client.log_and_retry_with_backoff(stub_response(413), [mock])
         end
@@ -156,6 +157,7 @@ module NewRelic
       def test_reaching_max_attempts_stops_retrying
         @client.instance_variable_set(:@max_retries, 5)
         @client.instance_variable_set(:@connection_attempts, 5)
+        # Retrying raises an exception, so we want to make sure there is no exception raised here
         @client.log_and_retry_with_backoff(stub_response(413), [mock])
       end
 

--- a/test/new_relic/telemetry_sdk/clients/client_test.rb
+++ b/test/new_relic/telemetry_sdk/clients/client_test.rb
@@ -36,6 +36,20 @@ module NewRelic
         @log_output.read
       end
 
+      def stub_server status, message = 'default message', headers = {}
+        response = stub_response status, message, headers
+        @connection.expects(:post).returns response
+      end
+
+      def stub_response status, message = 'default message', headers = {}
+        code = status.to_s
+        response = Net::HTTPResponse::CODE_TO_OBJ[code].new '1.1', code, message
+        headers.each do |key, value|
+          response.add_field key, value
+        end
+        response
+      end
+
       # We should be using the common format for payloads as described here:
       # https://github.com/newrelic/newrelic-telemetry-sdk-specs/blob/master/communication.md#payload
       def test_format_payload
@@ -104,19 +118,46 @@ module NewRelic
         @client.report @item
       end
 
-      def stub_server status, message = 'default message', headers = {}
-        response = stub_response status, message, headers
-        @connection.expects(:post).returns response
+      def test_backoff_calculation
+        # example numbers from the spec
+        expected =  [0, 1, 2, 4, 8, 16, 16, 16]
+        max_time = 16
+        factor = 1
+        (0..7).each do |attempt|
+          assert_equal expected[attempt], @client.calculate_backoff_strategy(attempt, factor, max_time)
+        end
+        # more examples from the spec
+        expected =  [0, 5, 10, 20, 40, 80, 80, 80]
+        max_time = 80
+        factor = 5
+        (0..7).each do |attempt|
+          assert_equal expected[attempt], @client.calculate_backoff_strategy(attempt, factor, max_time)
+        end
       end
 
-      def stub_response status, message = 'default message', headers = {}
-        code = status.to_s
-        response = Net::HTTPResponse::CODE_TO_OBJ[code].new '1.1', code, message
-        headers.each do |key, value|
-          response.add_field key, value
-        end
-        response
+      def test_backoff_strategy_increments_attempts
+        time = 13
+        @client.expects(:calculate_backoff_strategy).then.returns(time).once
+        attempts = @client.instance_variable_get(:@connection_attempts)
+        assert_equal time, @client.backoff_strategy
+        assert_equal attempts+1, @client.instance_variable_get(:@connection_attempts)
       end
+
+      def test_raises_before_max_retries
+        @client.expects(:backoff_strategy).then.returns(0).once
+        @client.instance_variable_set(:@max_retries, 5)
+        @client.instance_variable_set(:@connection_attempts, 4)
+        assert_raises NewRelic::TelemetrySdk::ServerConnectionException do 
+          @client.log_and_retry_with_backoff(mock, mock)
+        end
+      end
+
+      def test_reaching_max_attempts_stops_retrying
+        @client.instance_variable_set(:@max_retries, 5)
+        @client.instance_variable_set(:@connection_attempts, 5)
+        @client.log_and_retry_with_backoff(mock, mock)
+      end
+
     end
   end
 end

--- a/test/new_relic/telemetry_sdk/clients/client_test.rb
+++ b/test/new_relic/telemetry_sdk/clients/client_test.rb
@@ -5,6 +5,7 @@
 
 require File.expand_path(File.join(File.dirname(__FILE__),'../../..','test_helper'))
 require 'new_relic/telemetry_sdk/clients/client'
+require 'logger'
 
 module NewRelic
   module TelemetrySdk

--- a/test/new_relic/telemetry_sdk/clients/client_test.rb
+++ b/test/new_relic/telemetry_sdk/clients/client_test.rb
@@ -149,14 +149,14 @@ module NewRelic
         @client.instance_variable_set(:@max_retries, 5)
         @client.instance_variable_set(:@connection_attempts, 4)
         assert_raises NewRelic::TelemetrySdk::ServerConnectionException do 
-          @client.log_and_retry_with_backoff(mock, mock)
+          @client.log_and_retry_with_backoff(stub_response(413), mock)
         end
       end
 
       def test_reaching_max_attempts_stops_retrying
         @client.instance_variable_set(:@max_retries, 5)
         @client.instance_variable_set(:@connection_attempts, 5)
-        @client.log_and_retry_with_backoff(mock, mock)
+        @client.log_and_retry_with_backoff(stub_response(413), mock)
       end
 
       def test_splitting_payload
@@ -164,7 +164,7 @@ module NewRelic
         data = [1, 2, 3, 4]
         @client.expects(:report_batch).with([[1,2],common])
         @client.expects(:report_batch).with([[3,4],common])
-        @client.log_and_split_payload mock, data, common
+        @client.log_and_split_payload stub_response(413), data, common
       end
 
       def test_splitting_odd_payload
@@ -172,7 +172,7 @@ module NewRelic
         data = [1, 2, 3, 4, 5]
         @client.expects(:report_batch).with([[1,2,3],common])
         @client.expects(:report_batch).with([[4,5],common])
-        @client.log_and_split_payload mock, data, common
+        @client.log_and_split_payload stub_response(413), data, common
       end
 
     end

--- a/test/new_relic/telemetry_sdk/clients/client_test.rb
+++ b/test/new_relic/telemetry_sdk/clients/client_test.rb
@@ -94,9 +94,13 @@ module NewRelic
       end
 
       def test_status_server_error
-        # TODO: should retry based on backoff strategy
-        never_sleep
-        stub_server(500).once
+        sleep_time = 42
+        # makes sure that it is sleeping for the amount of time returned by the backoff calculation
+        @client.expects(:calculate_backoff_strategy).then.returns(sleep_time).once
+        @client.expects(:sleep).with(sleep_time).once
+
+        stub_server(500).then.returns(stub_response 200).times(2)
+
         @client.report @item
       end
 

--- a/test/new_relic/telemetry_sdk/logger_test.rb
+++ b/test/new_relic/telemetry_sdk/logger_test.rb
@@ -1,0 +1,64 @@
+# encoding: utf-8
+# frozen_string_literal: true
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-telemetry-sdk-ruby/blob/main/LICENSE for complete details.
+
+require File.expand_path(File.join(File.dirname(__FILE__),'../..','test_helper'))
+require "logger"
+
+module NewRelic
+  module TelemetrySdk
+    class LoggerTest < Minitest::Test
+      class FakeClient
+        include Logger
+      end
+
+      def setup
+        @fake_client = FakeClient.new
+        @log_output = StringIO.new
+        @fake_client.logger = ::Logger.new(@log_output)
+      end
+
+      def log_output
+        @log_output.rewind
+        @log_output.read
+      end
+
+      def test_log
+        @fake_client.logger.warn "FIRST"
+        @fake_client.logger.warn "SECOND"
+        assert_match "FIRST", log_output
+        assert_match "SECOND", log_output
+      end
+
+      # Level plays no role in logging once!  This test demonstrates that.
+      def test_log_once
+        @fake_client.log_once :warn, :foo, "FIRST"
+        @fake_client.log_once :error, :foo, "SECOND"
+        assert_match "FIRST", log_output
+        refute_match "SECOND", log_output
+      end
+
+      def test_warn_once
+        @fake_client.log_warn_once :foo, "FIRST"
+        @fake_client.log_warn_once :foo, "SECOND"
+        assert_match "WARN", log_output
+        assert_match "FIRST", log_output
+        refute_match "SECOND", log_output
+      end
+
+      def test_all_the_levels_once
+        @fake_client.log_debug_once :one, "FIRST"
+        @fake_client.log_warn_once :two, "SECOND"
+        @fake_client.log_error_once :three, "THIRD"
+        @fake_client.log_info_once :four, "FOURTH"
+        @fake_client.log_fatal_once :five, "FIFTH"
+        assert_match "FIRST", log_output
+        assert_match "SECOND", log_output
+        assert_match "THIRD", log_output
+        assert_match "FOURTH", log_output
+        assert_match "FIFTH", log_output
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR addressed https://github.com/newrelic/newrelic-telemetry-sdk-ruby/issues/7, adds handling for a variety of response codes the client can receive back. 

The details of the response codes expected behaviors can be found [here in the spec](https://github.com/newrelic/newrelic-telemetry-sdk-specs/blob/master/communication.md#response-codes).

Any other response not specified will attempt to resend the data in increasingly long intervals. This is based on a [calculation in the spec](https://github.com/newrelic/newrelic-telemetry-sdk-specs/blob/master/communication.md#graceful-degradation). The values used in this calculation will be based on configuration, but right now they are set to the same as the example in the spec. This will be updated when we address https://github.com/newrelic/newrelic-telemetry-sdk-ruby/issues/10

This PR also lays the groundwork for https://github.com/newrelic/newrelic-telemetry-sdk-ruby/issues/11, needed to log info from the responses in the client, as well as logging when data is dropped.