### PR TITLE
Bugfix: make default trace IDs and span IDs longer

### DIFF
--- a/lib/new_relic/telemetry_sdk/span.rb
+++ b/lib/new_relic/telemetry_sdk/span.rb
@@ -17,8 +17,8 @@ module NewRelic
                     :service_name,
                     :custom_attributes
 
-      def initialize id: Util.generate_guid(8),
-                     trace_id: Util.generate_guid(16),
+      def initialize id: Util.generate_guid(16),
+                     trace_id: Util.generate_guid(32),
                      start_time_ms: Util.time_to_ms,
                      duration_ms: nil,
                      name: nil,

--- a/test/new_relic/telemetry_sdk/span_test.rb
+++ b/test/new_relic/telemetry_sdk/span_test.rb
@@ -14,7 +14,11 @@ module NewRelic
       def test_required_attributes
         span = Span.new
         assert span.id.is_a? String
+        assert_equal 16, span.id.length
+
         assert span.trace_id.is_a? String
+        assert_equal 32, span.trace_id.length
+
         assert span.start_time_ms.is_a? Integer
       end
 


### PR DESCRIPTION
A small (but important) bugfix: trace IDs should be 32 hexadecimal characters by default and span IDs should be 16 hexadecimal characters long.