### PR TITLE
Data validation

### DIFF
--- a/lib/new_relic/telemetry_sdk.rb
+++ b/lib/new_relic/telemetry_sdk.rb
@@ -7,6 +7,7 @@ require 'net/http'
 require 'json'
 require 'zlib'
 require 'securerandom'
+require 'logger'
 
 module NewRelic
   module TelemetrySdk

--- a/lib/new_relic/telemetry_sdk/buffer.rb
+++ b/lib/new_relic/telemetry_sdk/buffer.rb
@@ -6,6 +6,8 @@
 module NewRelic
   module TelemetrySdk
     class Buffer
+      include NewRelic::TelemetrySdk::Logger
+
       attr_reader :items
       attr_accessor :common_attributes
 

--- a/lib/new_relic/telemetry_sdk/buffer.rb
+++ b/lib/new_relic/telemetry_sdk/buffer.rb
@@ -18,6 +18,9 @@ module NewRelic
       # Items recorded into the buffer must have a to_h method for transformation
       def record item
         @lock.synchronize { @items << item }
+      rescue => e
+        logger.error "Encountered error in buffer"
+        logger.error e
       end
 
       def flush
@@ -28,6 +31,9 @@ module NewRelic
         end
         data.map!(&:to_h)
         return data, @common_attributes
+      rescue => e
+        logger.error "Encountered error in buffer"
+        logger.error e
       end
     end
   end

--- a/lib/new_relic/telemetry_sdk/buffer.rb
+++ b/lib/new_relic/telemetry_sdk/buffer.rb
@@ -19,7 +19,7 @@ module NewRelic
       def record item
         @lock.synchronize { @items << item }
       rescue => e
-        logger.error "Encountered error in buffer"
+        logger.error "Encountered error while recording in buffer"
         logger.error e
       end
 
@@ -32,7 +32,7 @@ module NewRelic
         data.map!(&:to_h)
         return data, @common_attributes
       rescue => e
-        logger.error "Encountered error in buffer"
+        logger.error "Encountered error while flushing buffer"
         logger.error e
       end
     end

--- a/lib/new_relic/telemetry_sdk/buffer.rb
+++ b/lib/new_relic/telemetry_sdk/buffer.rb
@@ -21,7 +21,7 @@ module NewRelic
       def record item
         @lock.synchronize { @items << item }
       rescue => e
-        log_error e, "Encountered error while recording in buffer"
+        log_error "Encountered error while recording in buffer", e
       end
 
       def flush
@@ -33,7 +33,7 @@ module NewRelic
         data.map!(&:to_h)
         return data, @common_attributes
       rescue => e
-        log_error e, "Encountered error while flushing buffer"
+        log_error "Encountered error while flushing buffer", e
       end
     end
   end

--- a/lib/new_relic/telemetry_sdk/buffer.rb
+++ b/lib/new_relic/telemetry_sdk/buffer.rb
@@ -19,8 +19,7 @@ module NewRelic
       def record item
         @lock.synchronize { @items << item }
       rescue => e
-        logger.error "Encountered error while recording in buffer"
-        logger.error e
+        log_error e, "Encountered error while recording in buffer"
       end
 
       def flush
@@ -32,8 +31,7 @@ module NewRelic
         data.map!(&:to_h)
         return data, @common_attributes
       rescue => e
-        logger.error "Encountered error while flushing buffer"
-        logger.error e
+        log_error e, "Encountered error while flushing buffer"
       end
     end
   end

--- a/lib/new_relic/telemetry_sdk/clients/client.rb
+++ b/lib/new_relic/telemetry_sdk/clients/client.rb
@@ -35,8 +35,7 @@ module NewRelic
         # Report a batch of one pre-transformed item with no common attributes
         report_batch [[item.to_h], nil]
       rescue => e
-        logger.error "Encountered error reporting item in client. Dropping data: 1 point of data"
-        logger.error e
+        log_error e, "Encountered error reporting item in client. Dropping data: 1 point of data"
       end
 
       def report_batch batch_data
@@ -52,8 +51,7 @@ module NewRelic
         post_body = format_payload data, common_attributes
         send_with_response_handling post_body, data, common_attributes
       rescue => e
-        logger.error "Encountered error reporting batch in client. Dropping data: #{data.size} points of data"
-        logger.error e
+        log_error e, "Encountered error reporting batch in client. Dropping data: #{data.size} points of data"
       end
 
       def add_user_agent_product product, version=nil
@@ -79,8 +77,7 @@ module NewRelic
           add_user_agent_header @headers
         end
       rescue => e
-        logger.error "Encountered error adding user agent product"
-        logger.error e
+        log_error e, "Encountered error adding user agent product"
       end
 
     private

--- a/lib/new_relic/telemetry_sdk/clients/client.rb
+++ b/lib/new_relic/telemetry_sdk/clients/client.rb
@@ -51,9 +51,9 @@ module NewRelic
 
         post_body = format_payload data, common_attributes
         send_with_response_handling post_body, data, common_attributes
-        rescue => e
-          logger.error "Encountered error. Dropping data: #{data.size} points of data"
-          logger.error e.to_s
+      rescue => e
+        logger.error "Encountered error. Dropping data: #{data.size} points of data"
+        logger.error e.to_s
       end
 
     private

--- a/lib/new_relic/telemetry_sdk/clients/client.rb
+++ b/lib/new_relic/telemetry_sdk/clients/client.rb
@@ -53,7 +53,7 @@ module NewRelic
         send_with_response_handling post_body, data, common_attributes
       rescue => e
         logger.error "Encountered error. Dropping data: #{data.size} points of data"
-        logger.error e.to_s
+        logger.error e
       end
 
       def add_user_agent_product product, version=nil
@@ -78,6 +78,9 @@ module NewRelic
           @user_agent_products << entry
           add_user_agent_header @headers
         end
+      rescue => e
+        logger.error "Encountered error adding user agent product"
+        logger.error e
       end
 
     private

--- a/lib/new_relic/telemetry_sdk/clients/client.rb
+++ b/lib/new_relic/telemetry_sdk/clients/client.rb
@@ -35,8 +35,8 @@ module NewRelic
         # Report a batch of one pre-transformed item with no common attributes
         report_batch [[item.to_h], nil]
       rescue => e
-        logger.error e.to_s
-        logger.error "Encountered error. Dropping data: 1 point of data"
+        logger.error "Encountered error reporting item in client. Dropping data: 1 point of data"
+        logger.error e
       end
 
       def report_batch batch_data
@@ -52,7 +52,7 @@ module NewRelic
         post_body = format_payload data, common_attributes
         send_with_response_handling post_body, data, common_attributes
       rescue => e
-        logger.error "Encountered error. Dropping data: #{data.size} points of data"
+        logger.error "Encountered error reporting batch in client. Dropping data: #{data.size} points of data"
         logger.error e
       end
 

--- a/lib/new_relic/telemetry_sdk/harvester.rb
+++ b/lib/new_relic/telemetry_sdk/harvester.rb
@@ -49,8 +49,7 @@ module NewRelic
             harvest
             @running = false
           rescue => e
-            logger.error "Encountered error in harvester"
-            logger.error e
+            log_error e, "Encountered error in harvester"
           end
         end
       end
@@ -59,8 +58,7 @@ module NewRelic
         @shutdown = true
         @harvest_thread.join if @running
       rescue => e
-        logger.error "Encountered error stopping harvester"
-        logger.error e
+        log_error e, "Encountered error stopping harvester"
       end
 
     private

--- a/lib/new_relic/telemetry_sdk/harvester.rb
+++ b/lib/new_relic/telemetry_sdk/harvester.rb
@@ -50,6 +50,8 @@ module NewRelic
         @harvest_thread.join if @running
       end
 
+    private
+
       def harvest
         @lock.synchronize do
           @harvestables.values.each do |harvestable|

--- a/lib/new_relic/telemetry_sdk/harvester.rb
+++ b/lib/new_relic/telemetry_sdk/harvester.rb
@@ -26,8 +26,7 @@ module NewRelic
           }
         end
       rescue => e
-        logger.error "Encountered error while registering buffer #{name}."
-        logger.error e
+        log_error e, "Encountered error while registering buffer #{name}."
       end
 
       def [] name 

--- a/lib/new_relic/telemetry_sdk/harvester.rb
+++ b/lib/new_relic/telemetry_sdk/harvester.rb
@@ -26,7 +26,7 @@ module NewRelic
           }
         end
       rescue => e
-        log_error e, "Encountered error while registering buffer #{name}."
+        log_error "Encountered error while registering buffer #{name}.", e
       end
 
       def [] name 
@@ -48,7 +48,7 @@ module NewRelic
             harvest
             @running = false
           rescue => e
-            log_error e, "Encountered error in harvester"
+            log_error "Encountered error in harvester", e
           end
         end
       end
@@ -57,7 +57,7 @@ module NewRelic
         @shutdown = true
         @harvest_thread.join if @running
       rescue => e
-        log_error e, "Encountered error stopping harvester"
+        log_error "Encountered error stopping harvester", e
       end
 
     private

--- a/lib/new_relic/telemetry_sdk/logger.rb
+++ b/lib/new_relic/telemetry_sdk/logger.rb
@@ -39,6 +39,12 @@ module NewRelic
           @already_logged = {}
         end
       end
+
+      def log_error(exception, message)
+        logger.error message
+        logger.error exception
+      end
+
     end
   end
 end

--- a/lib/new_relic/telemetry_sdk/logger.rb
+++ b/lib/new_relic/telemetry_sdk/logger.rb
@@ -40,9 +40,9 @@ module NewRelic
         end
       end
 
-      def log_error(exception, message)
+      def log_error(message, exception = nil)
         logger.error message
-        logger.error exception
+        logger.error exception if exception
       end
 
     end

--- a/lib/new_relic/telemetry_sdk/span.rb
+++ b/lib/new_relic/telemetry_sdk/span.rb
@@ -39,8 +39,7 @@ module NewRelic
       def finish end_time_ms: Util.time_to_ms
         @duration_ms = end_time_ms - @start_time_ms
       rescue => e
-        logger.error "Encountered error finishing span"
-        logger.error e
+        log_error e, "Encountered error finishing span"
       end
 
       def to_h
@@ -60,8 +59,7 @@ module NewRelic
 
         data
       rescue => e
-        logger.error "Encountered error converting span to hash"
-        logger.error e
+        log_error e, "Encountered error converting span to hash"
       end
     end
   end

--- a/lib/new_relic/telemetry_sdk/span.rb
+++ b/lib/new_relic/telemetry_sdk/span.rb
@@ -42,7 +42,7 @@ module NewRelic
       def finish end_time_ms: Util.time_to_ms
         @duration_ms = end_time_ms - @start_time_ms
       rescue => e
-        log_error e, "Encountered error finishing span"
+        log_error "Encountered error finishing span", e
       end
 
       def to_h
@@ -62,7 +62,7 @@ module NewRelic
 
         data
       rescue => e
-        log_error e, "Encountered error converting span to hash"
+        log_error "Encountered error converting span to hash", e
       end
     end
   end

--- a/lib/new_relic/telemetry_sdk/span.rb
+++ b/lib/new_relic/telemetry_sdk/span.rb
@@ -39,7 +39,7 @@ module NewRelic
       def finish end_time_ms: Util.time_to_ms
         @duration_ms = end_time_ms - @start_time_ms
       rescue => e
-        logger.error "Encountered error in span"
+        logger.error "Encountered error finishing span"
         logger.error e
       end
 
@@ -60,7 +60,7 @@ module NewRelic
 
         data
       rescue => e
-        logger.error "Encountered error in span"
+        logger.error "Encountered error converting span to hash"
         logger.error e
       end
     end

--- a/lib/new_relic/telemetry_sdk/span.rb
+++ b/lib/new_relic/telemetry_sdk/span.rb
@@ -4,10 +4,13 @@
 # See https://github.com/newrelic/newrelic-telemetry-sdk-ruby/blob/main/LICENSE for complete details.
 
 require 'new_relic/telemetry_sdk/util'
+require 'new_relic/telemetry_sdk/logger'
 
 module NewRelic
   module TelemetrySdk
     class Span
+      include NewRelic::TelemetrySdk::Logger
+
       attr_accessor :id,
                     :trace_id,
                     :start_time_ms,

--- a/lib/new_relic/telemetry_sdk/span.rb
+++ b/lib/new_relic/telemetry_sdk/span.rb
@@ -38,6 +38,9 @@ module NewRelic
 
       def finish end_time_ms: Util.time_to_ms
         @duration_ms = end_time_ms - @start_time_ms
+      rescue => e
+        logger.error "Encountered error in span"
+        logger.error e
       end
 
       def to_h
@@ -56,6 +59,9 @@ module NewRelic
         data[:attributes].merge! @custom_attributes if @custom_attributes
 
         data
+      rescue => e
+        logger.error "Encountered error in span"
+        logger.error e
       end
     end
   end

--- a/test/new_relic/telemetry_sdk/clients/client_test.rb
+++ b/test/new_relic/telemetry_sdk/clients/client_test.rb
@@ -224,16 +224,16 @@ module NewRelic
         @client.stubs(:format_payload).raises(StandardError.new('pretend_error'))
         # if an error bubbles up here, test fails
         @client.report_batch [[@item, @item], nil]
-        assert_match /Encountered error./, log_output
-        assert_match /pretend_error/, log_output
+        assert_match(/Encountered error./, log_output)
+        assert_match(/pretend_error/, log_output)
       end
 
       def test_report_never_raises_error
         @client.stubs(:report_batch).raises(StandardError.new('pretend_error'))
         # if an error bubbles up here, test fails
         @client.report @item
-        assert_match /Encountered error./, log_output
-        assert_match /pretend_error/, log_output
+        assert_match(/Encountered error./, log_output)
+        assert_match(/pretend_error/, log_output)
       end
 
     end

--- a/test/new_relic/telemetry_sdk/clients/client_test.rb
+++ b/test/new_relic/telemetry_sdk/clients/client_test.rb
@@ -220,6 +220,22 @@ module NewRelic
         @client.send(:log_and_split_payload, stub_response(413), data, common)
       end
 
+      def test_report_batch_never_raises_error
+        @client.stubs(:format_payload).raises(StandardError.new('pretend_error'))
+        # if an error bubbles up here, test fails
+        @client.report_batch [[@item, @item], nil]
+        assert_match /Encountered error./, log_output
+        assert_match /pretend_error/, log_output
+      end
+
+      def test_report_never_raises_error
+        @client.stubs(:report_batch).raises(StandardError.new('pretend_error'))
+        # if an error bubbles up here, test fails
+        @client.report @item
+        assert_match /Encountered error./, log_output
+        assert_match /pretend_error/, log_output
+      end
+
     end
   end
 end

--- a/test/new_relic/telemetry_sdk/clients/client_test.rb
+++ b/test/new_relic/telemetry_sdk/clients/client_test.rb
@@ -67,7 +67,7 @@ module NewRelic
           }
         ]
 
-        payload = @client.format_payload(data, common_attributes)
+        payload = @client.send(:format_payload, data, common_attributes)
         assert_equal expected, payload
       end
 
@@ -161,14 +161,14 @@ module NewRelic
         max_time = 16
         factor = 1
         (0..7).each do |attempt|
-          assert_equal expected[attempt], @client.calculate_backoff_strategy(attempt, factor, max_time)
+          assert_equal expected[attempt], @client.send(:calculate_backoff_strategy, attempt, factor, max_time)
         end
         # more examples from the spec
         expected =  [0, 5, 10, 20, 40, 80, 80, 80]
         max_time = 80
         factor = 5
         (0..7).each do |attempt|
-          assert_equal expected[attempt], @client.calculate_backoff_strategy(attempt, factor, max_time)
+          assert_equal expected[attempt], @client.send(:calculate_backoff_strategy, attempt, factor, max_time)
         end
       end
 
@@ -176,7 +176,7 @@ module NewRelic
         time = 13
         @client.expects(:calculate_backoff_strategy).then.returns(time).once
         attempts = @client.instance_variable_get(:@connection_attempts)
-        assert_equal time, @client.backoff_strategy
+        assert_equal time, @client.send(:backoff_strategy)
         assert_equal attempts+1, @client.instance_variable_get(:@connection_attempts)
       end
 
@@ -186,7 +186,7 @@ module NewRelic
         @client.instance_variable_set(:@connection_attempts, 4)
         # Retry raises an exception, so we want the exception raised here
         assert_raises NewRelic::TelemetrySdk::RetriableServerResponseException do 
-          @client.log_and_retry_with_backoff(stub_response(413), [mock])
+          @client.send(:log_and_retry_with_backoff, stub_response(413), [mock])
         end
       end
 
@@ -194,7 +194,7 @@ module NewRelic
         @client.instance_variable_set(:@max_retries, 5)
         @client.instance_variable_set(:@connection_attempts, 5)
         # Retrying raises an exception, so we want to make sure there is no exception raised here
-        @client.log_and_retry_with_backoff(stub_response(413), [mock])
+        @client.send(:log_and_retry_with_backoff, stub_response(413), [mock])
       end
 
       def test_splitting_payload
@@ -202,7 +202,7 @@ module NewRelic
         data = [1, 2, 3, 4]
         @client.expects(:report_batch).with([[1,2],common])
         @client.expects(:report_batch).with([[3,4],common])
-        @client.log_and_split_payload stub_response(413), data, common
+        @client.send(:log_and_split_payload, stub_response(413), data, common)
       end
 
       def test_splitting_odd_payload
@@ -210,14 +210,14 @@ module NewRelic
         data = [1, 2, 3, 4, 5]
         @client.expects(:report_batch).with([[1,2,3],common])
         @client.expects(:report_batch).with([[4,5],common])
-        @client.log_and_split_payload stub_response(413), data, common
+        @client.send(:log_and_split_payload, stub_response(413), data, common)
       end
 
       def test_splitting_payload_of_one
         common = [test: 'test']
         data = []
         @client.expects(:report_batch).never
-        @client.log_and_split_payload stub_response(413), data, common
+        @client.send(:log_and_split_payload, stub_response(413), data, common)
       end
 
     end

--- a/test/new_relic/telemetry_sdk/clients/client_test.rb
+++ b/test/new_relic/telemetry_sdk/clients/client_test.rb
@@ -5,7 +5,6 @@
 
 require File.expand_path(File.join(File.dirname(__FILE__),'../../..','test_helper'))
 require 'new_relic/telemetry_sdk/clients/client'
-require 'logger'
 
 module NewRelic
   module TelemetrySdk

--- a/test/new_relic/telemetry_sdk/harvester_test.rb
+++ b/test/new_relic/telemetry_sdk/harvester_test.rb
@@ -118,6 +118,15 @@ module NewRelic
         assert_match(/pretend error/, log_output)
       end
 
+      def test_register_logs_error
+        harvester = Harvester.new 
+        harvester.logger = ::Logger.new(@log_output = StringIO.new)
+        harvester.instance_variable_get(:@lock).stubs(:synchronize).raises(StandardError.new('pretend_error'))
+        harvester.register("test buffer", stub, stub)
+        assert_match(/Encountered error while registering buffer test buffer./, log_output)
+        assert_match(/pretend_error/, log_output)
+      end
+
     end
   end
 end

--- a/test/new_relic/telemetry_sdk/harvester_test.rb
+++ b/test/new_relic/telemetry_sdk/harvester_test.rb
@@ -41,7 +41,7 @@ module NewRelic
         harvester.register 'test2', buffer, client
 
         Harvester.any_instance.expects(:process_harvestable).times(2)
-        harvester.harvest
+        harvester.send(:harvest)
       end
 
       # process_harvestable calles correct functions on buffer and client objects
@@ -54,7 +54,7 @@ module NewRelic
         buffer.expects(:flush).returns(flushed_buffer).once
         client.expects(:report_batch).once
 
-        harvester.process_harvestable ({buffer: buffer, client: client})
+        harvester.send(:process_harvestable, {buffer: buffer, client: client})
       end
 
       def test_process_harvestable_without_data
@@ -66,7 +66,7 @@ module NewRelic
         buffer.expects(:flush).returns(flushed_buffer).once
         client.expects(:report_batch).never
 
-        harvester.process_harvestable ({buffer: buffer, client: client})
+        harvester.send(:process_harvestable, {buffer: buffer, client: client})
       end
 
       def test_starts_stops_harvest_thread 

--- a/test/new_relic/telemetry_sdk/logger_test.rb
+++ b/test/new_relic/telemetry_sdk/logger_test.rb
@@ -4,7 +4,6 @@
 # See https://github.com/newrelic/newrelic-telemetry-sdk-ruby/blob/main/LICENSE for complete details.
 
 require File.expand_path(File.join(File.dirname(__FILE__),'../..','test_helper'))
-require "logger"
 
 module NewRelic
   module TelemetrySdk

--- a/test/new_relic/telemetry_sdk/span_test.rb
+++ b/test/new_relic/telemetry_sdk/span_test.rb
@@ -145,6 +145,7 @@ module NewRelic
         span = Span.new
         span.logger = ::Logger.new(@log_output = StringIO.new)
         time = stub
+        # Forcing an error to occur so we can log it
         time.stubs(:-).raises(StandardError.new('pretend_error'))
         span.finish(end_time_ms: time)
         assert_match(/pretend_error/, log_output)
@@ -154,6 +155,7 @@ module NewRelic
         span = Span.new(custom_attributes: stub)
         span.logger = ::Logger.new(@log_output = StringIO.new)
         span.to_h
+        # Created span with a stub object for custom attributes to force an error to occur so we can log it
         assert_match(/no implicit conversion of Mocha::Mock into Hash /, log_output)
       end
 

--- a/test/new_relic/telemetry_sdk/span_test.rb
+++ b/test/new_relic/telemetry_sdk/span_test.rb
@@ -11,6 +11,12 @@ require 'new_relic/telemetry_sdk/util'
 module NewRelic
   module TelemetrySdk
     class SpanTest < Minitest::Test
+
+      def log_output
+        @log_output.rewind
+        @log_output.read
+      end
+
       def test_required_attributes
         span = Span.new
         assert span.id.is_a? String
@@ -134,6 +140,23 @@ module NewRelic
 
         assert_equal expected_data, span.to_h
       end
+
+      def test_finish_logs_error
+        span = Span.new
+        span.logger = ::Logger.new(@log_output = StringIO.new)
+        time = stub
+        time.stubs(:-).raises(StandardError.new('pretend_error'))
+        span.finish(end_time_ms: time)
+        assert_match(/pretend_error/, log_output)
+      end
+
+      def test_to_h_logs_error
+        span = Span.new(custom_attributes: stub)
+        span.logger = ::Logger.new(@log_output = StringIO.new)
+        span.to_h
+        assert_match(/no implicit conversion of Mocha::Mock into Hash /, log_output)
+      end
+
     end
   end
 end


### PR DESCRIPTION
Adds rescue to public methods on the api to prevent errors from occurring and impacting the user.
[Per the spec](https://github.com/newrelic/newrelic-telemetry-sdk-specs/blob/a72a4739afa2fd252714f68b8aaefcd7e5da5bc2/validation.md#sdk-validation), Data validation must be only the minimal required to prevent errors from occurring.
 In order to satisfy the requirement "The SDK MUST NOT throw exceptions or errors on data ingest ", we've added rescuing and logging from all exceptions that occur in the public methods. 

Addresses this github issue: https://github.com/newrelic/newrelic-telemetry-sdk-ruby/issues/8